### PR TITLE
feat: support password via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ vim .env
 
 **Principais chaves**:
 - `DB_BACKEND=postgres`
-- `PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD` (ou `PG_DSN`)
+- `PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD` (obrigatório para conexão autenticada; ou `PG_DSN`)
 - `INPUT_TOPIC`, `MQTT_BROKER_HOST`, `MQTT_BROKER_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_TLS_*`
 
 ---

--- a/src/data_process_pg.py
+++ b/src/data_process_pg.py
@@ -46,7 +46,7 @@ class Settings:
     pg_port: int = int(os.getenv("PGPORT", "5432"))
     pg_db: str = os.getenv("PGDATABASE", "databridge")
     pg_user: str = os.getenv("PGUSER", "databridge")
-    #pg_pass: str = os.getenv("PGPASSWORD", "")
+    pg_pass: str = os.getenv("PGPASSWORD", "")
     pg_connect_timeout: int = int(os.getenv("PGCONNECT_TIMEOUT", "10"))
     pg_target_schema: str = os.getenv("PGSCHEMA", "ingest")
     pg_table: str = os.getenv("PGTABLE", "readings")
@@ -121,12 +121,15 @@ class Database:
     def _dsn(self) -> str:
         if self.settings.pg_dsn:
             return self.settings.pg_dsn
+        password_part = (
+            f"password={self.settings.pg_pass} " if self.settings.pg_pass else ""
+        )
         return (
             f"host={self.settings.pg_host} "
             f"port={self.settings.pg_port} "
             f"dbname={self.settings.pg_db} "
             f"user={self.settings.pg_user} "
-            #f"password={self.settings.pg_pass} "
+            f"{password_part}"
             f"connect_timeout={self.settings.pg_connect_timeout} "
             f"options='-c statement_timeout={self.settings.pg_stmt_timeout_ms}'"
         )


### PR DESCRIPTION
## Summary
- read optional PGPASSWORD env and expose as pg_pass in Settings
- inject pg_pass into DSN when provided
- document PGPASSWORD requirement for authenticated connections

## Testing
- `python -m py_compile src/data_process_pg.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1c6266d68832f9ee1e93ec50d970c