### PR TITLE
Add metrics and alerting for ingestion activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ vim .env
 - `DB_BACKEND=postgres`
 - `PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD` (ou `PG_DSN`)
 - `INPUT_TOPIC`, `MQTT_BROKER_HOST`, `MQTT_BROKER_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_TLS_*`
+- `METRICS_PORT` (porta HTTP para expor métricas Prometheus; padrão 8000)
+- `METRICS_LOG_INTERVAL_SEC` (intervalo de log periódico; padrão 60)
+- `INSERT_STALE_THRESHOLD_SEC` (alerta se sem inserções por X s; padrão 300)
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ paho-mqtt>=1.6.1
 python-dotenv>=1.0.1
 psycopg[binary,pool]>=3.1
 jsonschema>=4.0.0
+prometheus-client>=0.16.0

--- a/src/data_process_pg.py
+++ b/src/data_process_pg.py
@@ -13,6 +13,7 @@ import json
 import time
 import math
 import logging
+import threading
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -23,6 +24,7 @@ from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 import psycopg
 from psycopg.rows import tuple_row
+from prometheus_client import Counter, Gauge, start_http_server
 
 # ---------------------------------------------------------------------------
 # Dependências internas (mantidas)
@@ -81,6 +83,11 @@ class Settings:
     default_region: str = os.getenv("DEFAULT_REGION", "br_national")
     default_tz: str = os.getenv("DEFAULT_TZ", "America/Sao_Paulo")
 
+    # Métricas/monitoramento
+    metrics_port: int = int(os.getenv("METRICS_PORT", "8000"))
+    metrics_log_interval: int = int(os.getenv("METRICS_LOG_INTERVAL_SEC", "60"))
+    insert_stale_threshold: int = int(os.getenv("INSERT_STALE_THRESHOLD_SEC", "300"))
+
 
 SETTINGS = Settings()
 
@@ -89,6 +96,14 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 logger = logging.getLogger("data-process-pg")
+
+# Métricas Prometheus
+INSERTIONS_COUNTER = Counter(
+    "db_insertions_total", "Total de inserções bem-sucedidas"
+)
+LAST_INSERT_GAUGE = Gauge(
+    "db_last_insert_timestamp", "Timestamp da última inserção (epoch)"
+)
 
 # ---------------------------------------------------------------------------
 # Constantes de Domínio / Mapas Regionais
@@ -445,6 +460,8 @@ def compute_hourly_expected_from_daily_weekend(db: Database, profile: str, devic
 class Processor:
     def __init__(self, db: Database):
         self.db = db
+        self.insert_count = 0
+        self.last_insert_ts: Optional[float] = None
 
     def handle_message(self, topic: str, payload_bytes: bytes) -> None:
         try:
@@ -485,6 +502,11 @@ class Processor:
         try:
             self.db.insert_reading(profile, device_name, application_name, ts_iso, payload_json)
             logger.debug(f"Persistido {profile}/{device_name} @ {ts_iso}")
+            self.insert_count += 1
+            now = time.time()
+            self.last_insert_ts = now
+            INSERTIONS_COUNTER.inc()
+            LAST_INSERT_GAUGE.set(now)
         except Exception as e:
             logger.error(f"Erro ao inserir {profile}/{device_name}@{ts_iso}: {e}")
 
@@ -616,6 +638,33 @@ class Processor:
             values[prefix + "n_days"] = n
 
 # ---------------------------------------------------------------------------
+# Monitoramento e métricas
+# ---------------------------------------------------------------------------
+
+class MetricsMonitor:
+    def __init__(self, processor: "Processor", settings: Settings):
+        self.processor = processor
+        self.interval = settings.metrics_log_interval
+        self.threshold = settings.insert_stale_threshold
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+
+    def _run(self) -> None:
+        while True:
+            time.sleep(self.interval)
+            count = self.processor.insert_count
+            last = self.processor.last_insert_ts
+            last_str = (
+                datetime.fromtimestamp(last, tz=UTC).isoformat() if last else "n/a"
+            )
+            logger.info(
+                f"stats insertions_total={count} last_insert={last_str}"
+            )
+            if last and (time.time() - last) > self.threshold:
+                delta = int(time.time() - last)
+                logger.warning(f"Sem novas inserções há {delta}s")
+
+# ---------------------------------------------------------------------------
 # MQTT Wiring
 # ---------------------------------------------------------------------------
 
@@ -667,8 +716,10 @@ class MqttApp:
 # ---------------------------------------------------------------------------
 
 def main():
+    start_http_server(SETTINGS.metrics_port)
     db = Database(SETTINGS)
     processor = Processor(db)
+    MetricsMonitor(processor, SETTINGS)
     app = MqttApp(SETTINGS, processor)
     app.run_forever()
 


### PR DESCRIPTION
## Summary
- track total DB insertions and last insert timestamp
- expose metrics via Prometheus and log heartbeat with stale data alert
- document new environment variables

## Testing
- `python -m py_compile src/data_process_pg.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement prometheus-client>=0.16.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c62a2a68832fbfd3d10a549c3eb4